### PR TITLE
회원가입 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-colorful": "^5.6.1",
         "react-dom": "^17.0.2",
         "react-redux": "^8.0.4",
+        "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
         "web-vitals": "^2.1.4"
@@ -4241,6 +4242,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.2.tgz",
+      "integrity": "sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -15730,6 +15739,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.2.tgz",
+      "integrity": "sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==",
+      "dependencies": {
+        "@remix-run/router": "1.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.2.tgz",
+      "integrity": "sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==",
+      "dependencies": {
+        "@remix-run/router": "1.0.2",
+        "react-router": "6.4.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -21530,6 +21569,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@remix-run/router": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.2.tgz",
+      "integrity": "sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -29794,6 +29838,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.2.tgz",
+      "integrity": "sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==",
+      "requires": {
+        "@remix-run/router": "1.0.2"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.2.tgz",
+      "integrity": "sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==",
+      "requires": {
+        "@remix-run/router": "1.0.2",
+        "react-router": "6.4.2"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-colorful": "^5.6.1",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.4",
+    "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
     "web-vitals": "^2.1.4"

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,15 @@
 
+import { Route, Routes } from 'react-router-dom';
 import './App.css';
+import Join from './Pages/Join';
+import Login from './Pages/Login';
 
 function App() {
   return (
-    <div className="App">
-      app
-    </div>
+    <Routes>
+      <Route path="login" element ={<Login/>}></Route>
+      <Route path="/join" element={<Join/>}></Route>
+    </Routes>
   );
 }
 

--- a/src/Pages/Join.jsx
+++ b/src/Pages/Join.jsx
@@ -1,0 +1,54 @@
+import {Alert, Avatar, Grid, TextField, Typography} from '@mui/material';
+import {Box, Container} from '@mui/system';
+import React from 'react';
+import TagIcon from '@mui/icons-material/Tag';
+import {LoadingButton} from '@mui/lab';
+import { Link } from 'react-router-dom';
+
+function Join() {
+  return (
+    <Container component="main" maxWidth="xs">
+      <Box
+        sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100vh'}}
+      >
+        <Avatar sx={{m: 1, bgcolor: 'secondary.main'}}>
+          <TagIcon />
+        </Avatar>
+        <Typography component="h1" variant="h5">
+          회원가입
+        </Typography>
+        <Box component="form" noValidate sx={{mt: 3}} >
+                  <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <TextField name="name" required fullWidth label="닉네임" autoFocus></TextField>
+            </Grid>
+            <Grid item xs={12}>
+              <TextField name="email" required fullWidth label="이메일 주소"></TextField>
+            </Grid>
+            <Grid item xs={12}>
+              <TextField name="password" required fullWidth label="비밀번호" type="password"></TextField>
+            </Grid>
+            <Grid item xs={12}>
+              <TextField name="confirmPassword" required fullWidth label="확인 비밀번호" type="password"></TextField>
+            </Grid>
+          </Grid>
+          <Alert sx={{mt: 3}} severity="error">
+            에러메시지
+          </Alert>
+          <LoadingButton type="submit" fullWidth variant="contained" color="secondary" sx={{mt: 3, mb: 2}}>
+            회원 가입
+          </LoadingButton>
+          <Grid container justifyContent="flex-end">
+            <Grid item>
+              <Link to="/login" style={{textDecoration: 'none', color: 'blue'}}>
+                이미 계정이 있나요? 로그인으로 이동하기 -&gt;
+              </Link>
+            </Grid>
+          </Grid>
+        </Box>
+      </Box>
+    </Container>
+  );
+}
+
+export default Join;

--- a/src/Pages/Login.jsx
+++ b/src/Pages/Login.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+function Login() {
+  return (
+    <div>
+      login
+    </div>
+  )
+}
+
+export default Login

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
 // const root = ReactDOM.createRoot(document.getElementById('root'));
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );
 


### PR DESCRIPTION
* 이전에 설치하지 않은 `react-router-dom` 설치

* `Routes`를 사용해서 회원가입 페이지 `Join`구현함. `Material UI`를 사용해서 `Container` 내부의 `Box`로 구현함

* 하단의 `로그인으로 이동하기`을 클릭하면 `login`페이지로 이동하는 기능을 추가( 아직 로그인 페이지의 구현은 완료되지 않음