### PR TITLE
firbase signup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,33 @@
 
-import { Route, Routes } from 'react-router-dom';
+import { onAuthStateChanged } from 'firebase/auth';
+import { useEffect } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import './App.css';
 import Join from './Pages/Join';
 import Login from './Pages/Login';
+import { getAuth } from 'firebase/auth';
+import { useDispatch, useSelector } from 'react-redux';
+import { clearUser, setUser } from './store/userReducer';
+import Main from './Pages/Main';
 
 function App() {
+  const dispatch = useDispatch()
+  const {isLoading, currentUser} = useSelector((state) => state.user)
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(getAuth(), (user) => {
+      if (!!user) {
+        dispatch(setUser(user))
+      } else {
+        dispatch(clearUser())
+      }
+    })
+    return () => unsubscribe();
+  },[dispatch])
   return (
     <Routes>
+      <Route path="/" element={<Main/>}></Route>
       <Route path="login" element ={<Login/>}></Route>
-      <Route path="/join" element={<Join/>}></Route>
+      <Route path="/join" element={ currentUser ? <Navigate to="/"/> : <Join/>}></Route>
     </Routes>
   );
 }

--- a/src/Pages/Join.jsx
+++ b/src/Pages/Join.jsx
@@ -1,13 +1,80 @@
 import {Alert, Avatar, Grid, TextField, Typography} from '@mui/material';
 import {Box, Container} from '@mui/system';
-import React from 'react';
+import React, {useState} from 'react';
 import TagIcon from '@mui/icons-material/Tag';
 import {LoadingButton} from '@mui/lab';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
+import { useEffect } from 'react';
+import "../firebase"
+import {getAuth, createUserWithEmailAndPassword, updateProfile} from "firebase/auth"
+import md5 from 'md5';
+import { getDatabase, ref, set } from "firebase/database";
+import { setUser } from './../store/userReducer';
+import { useDispatch } from 'react-redux';
+
+
+
+
 
 function Join() {
+    const dispatch = useDispatch();
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false)
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const name = data.get('name');
+    const email = data.get('email');
+    const password = data.get('password');
+    const confirmPassword = data.get('confirmPassword');
+
+    if (!name || !email || !password || !confirmPassword) {
+      setError('모든 항목을 입력해주세요');
+      return;
+      }
+      if (password.length < 6 || confirmPassword.length < 6) {
+        setError('비밀번호는 최소 6자 이상이어야 합니다');
+        return;
+      } else if (password !== confirmPassword) {
+        setError('비밀번호와 확인비밀번호가 일치하지 않습니다')
+          return;
+      }
+    
+      postUserData(name,email,password)
+    };
+
+
+    const postUserData = async (name, email, password) => {
+        setLoading(true)
+        try {
+            
+            const { user } = await createUserWithEmailAndPassword(getAuth(), email, password);
+            await updateProfile(user, {
+                displayName: name,
+                photoURL:`https:/www.gravatar.com/avatar/${md5(email)}?d=retro`
+            })
+
+            await set(ref(getDatabase(), 'users/' + user.uid), {
+                name: user.displayName,
+                avatar: user.photoURL
+            })
+
+            dispatch(setUser(user))
+            console.log(user)
+            
+            // store 에 user 저장
+        } catch (e) {
+            setError(e.message);
+            setLoading(false);
+        }
+    }
+    
+    useEffect(() => {
+        if (!error) return;
+        setTimeout(() => {setError("")}, 3000)
+    },[error])
   return (
-    <Container component="main" maxWidth="xs">
+    <Container component="main" maxWidth="xs" sx={{transition:"all 1s"}}>
       <Box
         sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100vh'}}
       >
@@ -17,8 +84,8 @@ function Join() {
         <Typography component="h1" variant="h5">
           회원가입
         </Typography>
-        <Box component="form" noValidate sx={{mt: 3}} >
-                  <Grid container spacing={2}>
+        <Box component="form" noValidate sx={{mt: 3 }} onSubmit={handleSubmit}>
+          <Grid container spacing={2}>
             <Grid item xs={12}>
               <TextField name="name" required fullWidth label="닉네임" autoFocus></TextField>
             </Grid>
@@ -32,15 +99,18 @@ function Join() {
               <TextField name="confirmPassword" required fullWidth label="확인 비밀번호" type="password"></TextField>
             </Grid>
           </Grid>
-          <Alert sx={{mt: 3}} severity="error">
-            에러메시지
-          </Alert>
-          <LoadingButton type="submit" fullWidth variant="contained" color="secondary" sx={{mt: 3, mb: 2}}>
+          {error ? (
+            <Alert sx={{mt: 3}} severity="error">
+             {error}
+            </Alert>
+          ) : null}
+
+          <LoadingButton type="submit" fullWidth variant="contained" color="secondary" sx={{mt: 3, mb: 2}} loading={loading}>
             회원 가입
           </LoadingButton>
           <Grid container justifyContent="flex-end">
             <Grid item>
-              <Link to="/login" style={{textDecoration: 'none', color: 'blue'}}>
+                          <Link to="/login" style={{ textDecoration: "none", color: 'blue'}} >
                 이미 계정이 있나요? 로그인으로 이동하기 -&gt;
               </Link>
             </Grid>

--- a/src/Pages/Main.jsx
+++ b/src/Pages/Main.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+function Main() {
+  return (
+    <div>
+      Main
+    </div>
+  )
+}
+
+export default Main

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,18 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { legacy_createStore } from 'redux';
+import rootReducer from './store/index';
 
 // const root = ReactDOM.createRoot(document.getElementById('root'));
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={legacy_createStore(rootReducer)}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root'),
 );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,10 @@
+
+import { combineReducers } from "redux";
+import userReducer from './userReducer';
+
+const rootReducer = combineReducers({
+    user: userReducer,
+})
+
+
+export default rootReducer;

--- a/src/store/userReducer.js
+++ b/src/store/userReducer.js
@@ -1,0 +1,31 @@
+const SET_USER = "SET_USER"
+const CLEAR_USER = "CLEAR_USER"
+
+export const setUser = (user) => ({ type: SET_USER, currentUser: user });
+export const clearUser = () => ({ type: CLEAR_USER })
+
+
+const initialState = {
+    currentUser: null,
+    isLoading: true,
+}
+
+const userReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case SET_USER:
+            return {
+                currentUser: action.currentUser,
+                isLoading: false,
+            }
+        case CLEAR_USER:
+            return {
+              currentUser:null,
+              isLoading: false,
+            };
+        
+        default: return state;
+    }
+}
+
+
+export default userReducer;


### PR DESCRIPTION
# 회원가입 reducer 구현

* 회원가입 양식 작성시 user값을 지정하는 액션 타입과 현재 유저 값을 제거하는 액션 타입을 작성함

* 로그아웃을 했을 때 현재 유저 정보를 지워서 로그아웃이 되었다는 상태를 표시하기 위함

#  회원가입 기능 구현

* 사용자가 회원가입 양식의 내용을 작성하고 회원 가입 버튼을 누르면  `Box` 컴포넌트의 `handleSubmit`이 호출됨

* `handleSubmit`은 사용자가 입력한 데이터를 각각 가져온다음 데이터가 회원가입 절차를 진행하는데 있어서 문제유무 여부를 파악하고, 조건을 만족하지 않으면 오류 메시지를 나타나게 함.

* 오류의 종류
- 모든 항목이 입력되지 않았을 때
- 비밀번호의 자릿수가 6자 미만일 때
- 비밀번호와 확인 비밀번호의 값이 동일하지 않을 때

* 오류가 없다고 판단되면 firebase의 데이터베이스에 데이터를 저장하는 메서드(`postUserData`)를 호출함

* `postUserData`는 `createUserWithEmailAndPassword`를 사용해서 사용자가 작성한 데이터를 가져오고 `updateProfile`을 통해  `displayName`과 `photoURL`을 지정하며 이는 사용자의 프로필관리를 위해 사용됨. `photoURL`은 `gravatar.com`을 사용해서 임의로 선정된 이미지 타입이 나타나게 설정함

https://ko.gravatar.com/site/implement/images/

* firebase의 실시간 데이터베이스엔 users/ 경로하위에 user의 고유 id값을 이름으로 가진 데이터 하위에 `name`과 `avatar`라는 이름으로 이전에 지정한 데이터를  각각 저장한다.

* 그리고 `setUser`를 `dispatch`해서 `currentUser의 값을 해당 user값으로 지정함
회원 가입을 할때마다 user의 데이터 형태를 콘솔창으로 표시되게 설정함

* `App`의 `Route`에서 `currentUser`의 값이 존재하는 경우에는 회원가입 페이지 경로로 이동하려고 하면 `Main`으로 이동하게 설정하고 사용자가 로그아웃을 한 경우 `currentUser`의 값이 존재하지 않기 때문에 회원가입 페이지로 이동이 가능하게 설정함

* 메인페이지는 간략하게만 표시했으며, 로그아웃 기능을 구현하지 않았기 때문에 firbase에서 authentication 목록에서 데이터를 직접 제거하거나 중지시켜서 작동여부를 확인했음. 추후 기능 구현 예정


This closes #7 


