### PR TITLE
채널 메뉴 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
+        "redux-devtools-extension": "^2.13.9",
         "web-vitals": "^2.1.4"
       }
     },
@@ -15919,6 +15920,15 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-devtools-extension": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
+      "deprecated": "Package moved to @redux-devtools/extension.",
+      "peerDependencies": {
+        "redux": "^3.1.0 || ^4.0.0"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -29972,6 +29982,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-devtools-extension": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
+    "redux-devtools-extension": "^2.13.9",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/ChannelMenu.jsx
+++ b/src/components/ChannelMenu.jsx
@@ -12,15 +12,53 @@ import {
   ListItemText,
   TextField,
 } from '@mui/material';
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import AddIcon from '@mui/icons-material/Add';
+import "../firebase"
+import { child, getDatabase, onChildAdded, push, ref, update } from 'firebase/database';
+import { useEffect } from 'react';
 
 function ChannelMenu() {
   const [open, setOpen] = useState(false);
   const [channelName, setChannelName] = useState('');
   const [channelDetail, setChannelDetail] = useState('');
+  const [channels, setChannels] = useState([]);
   const handleClickOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+
+  useEffect(() => {
+    const db = getDatabase();
+    const unsubscribe = onChildAdded(ref(db, "channels"), (snapshot) => {
+      setChannels((channelArr) =>[...channelArr, snapshot.val()] )
+    })
+
+    return () => {
+      setChannels([])
+      unsubscribe()
+    }
+  },[])
+
+  const handleSubmit = useCallback(async () => {
+    //firebase의 데이터베이스에 데이터를 등록
+    const db = getDatabase();
+    const key = push(child(ref(db), "channels")).key;
+    const newChannel = {
+      id: key,
+      name: channelName,
+      details: channelDetail
+    };
+    const updates = {};
+    updates["/channels/" + key] = newChannel
+
+    try {
+      await update(ref(db), updates)
+      setChannelName("")
+      setChannelDetail("")
+      handleClose()
+    } catch (error) {
+      console.error(error)
+    }
+  },[channelDetail, channelName])
 
   return (
     <>
@@ -37,6 +75,12 @@ function ChannelMenu() {
             <ListItemText primary="채널" sx={{wordBreak: 'break-all', color: '#9a939b'}} />
           </ListItemIcon>
         </ListItem>
+        {channels.map((channel) => (
+          // TODO store 구현 , selected 구현
+          <ListItem button key={channel.id}>
+            <ListItemText primary={`# ${channel.name}`} sx={{wordBreak: 'break-all', color: '#9a939b'}} />
+          </ListItem>
+        ))}
       </List>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>채널 추가</DialogTitle>
@@ -62,7 +106,7 @@ function ChannelMenu() {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>취소</Button>
-          <Button>생성</Button>
+          <Button onClick={handleSubmit}>생성</Button>
         </DialogActions>
       </Dialog>
     </>

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,12 @@ import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { legacy_createStore } from 'redux';
 import rootReducer from './store/index';
+import { composeWithDevTools } from 'redux-devtools-extension';
 
 // const root = ReactDOM.createRoot(document.getElementById('root'));
 ReactDOM.render(
   <React.StrictMode>
-    <Provider store={legacy_createStore(rootReducer)}>
+    <Provider store={legacy_createStore(rootReducer, composeWithDevTools())}>
       <BrowserRouter>
         <App />
       </BrowserRouter>

--- a/src/store/channelReducer.js
+++ b/src/store/channelReducer.js
@@ -1,0 +1,18 @@
+const SET_CURRENT_CHANNEL = "SET_CURRENT_CHANNEL";
+
+export const setCurrentChannel = (channel) => ({ type: SET_CURRENT_CHANNEL, currentChannel: channel });
+
+const initialState = { currentChannel: null };
+
+const channelReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case SET_CURRENT_CHANNEL:
+            return {
+                currentChannel:action.currentChannel
+            }
+        default:
+            return state;
+    }
+}
+
+export default channelReducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,11 @@
 
 import { combineReducers } from "redux";
+import channelReducer from "./channelReducer";
 import userReducer from './userReducer';
 
 const rootReducer = combineReducers({
     user: userReducer,
+    channel: channelReducer
 })
 
 


### PR DESCRIPTION
# 채널 추가 

* 채널 추가 버튼을 클릭하여 나타난 `Dialog`에 채널 이름과 설명을 입력하고 생성 버튼을 누르면 `handleSubmit`을 호출하여 채널 목록에 추가되는 기능을 구현함

* `handleSubmit`은 먼저 사용자가 작성한 데이터를 firebase의 실시간 데이터베이스에 등록함. 이때 등록되는 데이터베이스의 이름을 `channels`로 지정하고 id(고유 키값), name,details(사용자가 작성한 데이터)를 `newChannel`이라는 객체로 감싸서  updates라는 빈 객체에 [`channels`,고유키] 항목에 `newChannel`을 추가시킴

* `update`메서드를 호출해서 firebase 데이터베이스에 `updates`를 추가하고, 사용자가 작성했던 값을 초기화 시킨뒤 `Dialog`가 꺼지게 설정함


* 데이터베이스에 추가될 때 `channels` 리스트에 이전의 데이터와 함께 추가된 데이터를 추가해줘서 페이지에 렌더링 될수 있도록 작성함

* `channels`의 길이만큼 `ListItem`을 반복 렌더링하고 이때의 key값은 `channel.id`값으로 지정함


# 선택 채널 관리

* 사용자가 처음으로 페이지로 이동할때는 첫 번째의 채널이 선택된 상태가 되도록 useEffect를 통해 설정함

* 만약 생성된 채널중에 하나를 클릭하여 선택할 때 `changeChannel` 메서드가 호출되게 설정함. 
`changeChannel`은 클릭한 채널의 id값을 `ActiveChannelId`의 값과 동일하게 만들어줌

`selected`의 기준은 `channel.id`와 `activeChannelId`의 값이 동일한 경우에 적용되기 때문에 클릭한 채널이 `selected`상태로 변함

* 컴포넌트 내부 뿐만아니라 전역에서 상태 변화를 파악하기 위해서 redux를 활용하여 store 내부에 `channelReducer`를 작성함

* `channelReducer` 는 `CurrentChannel`의 값을 변경하는 `setCurrentChannel`액션 생성함수만 보유하고 있음

* 사용자가 다른 채널을 클릭할때마다 , 혹은 새로고침을 할때(무조건 첫번째 채널이 선택되게 설정했기 때문)`setCurrentChannel`을 dispatch 해서 `currentChannel`이 변동되는 것을 파악함

* redux사용을 위해 `redux-devtools-extension`설치 및 index에 `devTool`사용 코드 추가함


This closes #15 
