### PR TITLE
메시지 영역 UI 구현

### DIFF
--- a/src/Pages/Main.jsx
+++ b/src/Pages/Main.jsx
@@ -3,20 +3,24 @@ import { Box } from '@mui/system';
 import Header from '../components/Header';
 import { Drawer, Toolbar } from '@mui/material';
 import ChannelMenu from '../components/ChannelMenu';
+import Chat from '../components/Chat/Chat';
 
 function Main() {
     return (
       //TODO backgroundColor 테마 적용
-      <Box sx={{display:"flex", backgroundColor:'white'}}>
-            <Header></Header>
-            <Drawer variant="permanent" sx={{width: 300}} className="no-scroll">
-                <Toolbar />
-                <Box sx={{ display: "flex", minHeight: "calc(100vh - 64px)" }}>
-                   <ChannelMenu></ChannelMenu>
-                </Box>
-            </Drawer>
-    </Box>
-  )
+      <Box sx={{display: 'flex', backgroundColor: 'white'}}>
+        <Header></Header>
+        <Drawer variant="permanent" sx={{width: 300}} className="no-scroll">
+          <Toolbar />
+          <Box sx={{display: 'flex', minHeight: 'calc(100vh - 64px)'}}>
+            <ChannelMenu></ChannelMenu>
+          </Box>
+        </Drawer>
+        <Box component="main" sx={{flexGrow:1, p:3}}>
+          <Chat/>
+        </Box>
+      </Box>
+    );
 }
 
 export default Main

--- a/src/components/Chat/Chat.jsx
+++ b/src/components/Chat/Chat.jsx
@@ -1,0 +1,24 @@
+import { Divider, Grid, List, Paper, Toolbar } from '@mui/material'
+import React from 'react'
+import ChatHeader from './ChatHeader'
+import { useSelector } from 'react-redux';
+import ChatInput from './ChatInput';
+
+function Chat() {
+     const {channel} = useSelector((state) => state);
+  return (
+    <>
+      <Toolbar />
+          <ChatHeader channelInfo={channel.currentChannel} />
+          <Grid container component={Paper} variant="outlined" sx={{ mt: 3, position: "relative" }}>
+              <List sx={{ height: "calc(100vh - 350px)", overflow: "scroll", width: "100%", position: "relative" }}> 
+                  {/* 채팅메세지 */}
+              </List>
+              <Divider />
+              <ChatInput/>
+          </Grid>
+    </>
+  );
+}
+
+export default Chat

--- a/src/components/Chat/ChatHeader.jsx
+++ b/src/components/Chat/ChatHeader.jsx
@@ -1,0 +1,16 @@
+import { CardContent, Grid, Paper, Typography } from '@mui/material'
+import React from 'react'
+
+function ChatHeader({channelInfo}) {
+   
+  return (
+    <Grid container component={Paper} varient="outlined">
+      <CardContent>
+              <Typography variant="h5"># {channelInfo?.name}</Typography>
+        <Typography variant="body1">{channelInfo?.details}</Typography>
+      </CardContent>
+    </Grid>
+  );
+}
+
+export default ChatHeader

--- a/src/components/Chat/ChatInput.jsx
+++ b/src/components/Chat/ChatInput.jsx
@@ -1,0 +1,42 @@
+import { InsertEmoticon } from '@mui/icons-material'
+import { Grid, IconButton, InputAdornment, TextField } from '@mui/material'
+import React from 'react'
+import ImageIcon from '@mui/icons-material/Image';
+import SendIcon from '@mui/icons-material/Send';
+function ChatInput() {
+  return (
+      <Grid container sx={{ p: "20px" }}>
+          <Grid item xs={12} sx={{ position: 'relative' }}>
+              <TextField
+                  InputProps={{
+                      startAdornment: (
+                          <InputAdornment position="start">
+                              <IconButton>
+                                  <InsertEmoticon/>
+                              </IconButton>
+                              <IconButton>
+                                  <ImageIcon/>
+                              </IconButton>
+                          </InputAdornment>
+                      ),
+                      endAdornment: (
+                          <InputAdornment positon="start">
+                              <IconButton>
+                                  <SendIcon/>
+                              </IconButton>
+                          </InputAdornment>
+                      )
+                  }}
+                  autoComplete="off"
+                  label="메세지 입력"
+                  fullWidth
+              >
+                  
+              </TextField>
+          </Grid>
+          
+    </Grid>
+  )
+}
+
+export default ChatInput


### PR DESCRIPTION
* 메시지 영역 UI를 구현한 `Chat` 컴포넌트를 추가함
 
* `ChatHeader`와 `Grid` 컴포넌트로 구성되어있으며 `Grid`내부에는 `ChatInput`컴포넌트가 들어있으며 TextField 컴포넌트로 채팅을 입력하는 영역임

* `ChatHeader`는 redux에서 관리하는 state에서 가져온 `currentChannel`을 props로 받아와서 채널의 이름(name) 과 자세한 설명(detail) 데이터를 표시함

*`ChatInput` 은 `TextFiled`컴포넌트를 사용했으며 `InputProps`를 추가해서 좌측에는 이모티콘과 이미지를 삽입하는 기능을 뜻하는 `IconButton`을 추가했으며 우측에는 메시지 전송을 뜻하는 `SendIcon`을 추가함