### PR TITLE
프로필 이미지 변경 기능 구현

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import {AppBar, Avatar, IconButton, Menu, MenuItem, Toolbar, Typography} from '@mui/material';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {Box} from '@mui/system';
 import TagIcon from '@mui/icons-material/Tag';
 import "../firebase"
@@ -7,18 +7,29 @@ import "../firebase"
 import { useSelector } from 'react-redux';
 import { signOut } from 'firebase/auth';
 import { getAuth } from 'firebase/auth';
+import ProfileModal from './Modal/ProfileModal';
 function Header() {
+  const [showProfileModal, setShowProfileModal] = useState(false);
     const { user } = useSelector(state => state)
-    const [anchorEl, setAnchorEl] = useState(null);
+  const [anchorEl, setAnchorEl] = useState(null);
+ 
+  const handleCloseMenu = () => setAnchorEl(null);
+   const handleLogout = async () => {
+     await signOut(getAuth());
+   };
+  
+  const handleClickOpen = useCallback(() => {
+    setShowProfileModal(true)
+    handleCloseMenu()
+  }, [])
+  
     const handleOpenMenu = (event) => {
         setAnchorEl(event.currentTarget)
     } 
 
-    const handleCloseMenu = () => setAnchorEl(null)
-    const handleLogout = async() => {
-        await signOut(getAuth())
-    }
-    
+  const handleCloseProfileModal = useCallback(() => { setShowProfileModal(false) },[])
+  
+  
 
   return (
     <>
@@ -42,7 +53,7 @@ function Header() {
               <Avatar sx={{ml: '10px'}} alt="profileImage" src={user.currentUser?.photoURL} />
             </IconButton>
             <Menu sx={{mt: '45px'}} anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleCloseMenu} anchorOrigin={{vertical:"top", horizontal:"right"}}>
-              <MenuItem>
+              <MenuItem onClick={handleClickOpen}>
                 <Typography textAlign="center">프로필이미지</Typography>
               </MenuItem>
                           <MenuItem onClick={handleLogout}>
@@ -52,6 +63,7 @@ function Header() {
           </Box>
         </Toolbar>
       </AppBar>
+      <ProfileModal open={showProfileModal} handleClose={handleCloseProfileModal} />
     </>
   );
 }

--- a/src/components/Modal/ProfileModal.jsx
+++ b/src/components/Modal/ProfileModal.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Input, Stack } from '@mui/material';
+import { useCallback } from 'react';
+import AvatarEditor from 'react-avatar-editor';
+
+function ProfileModal({ open, handleClose }) {
+    const [previewImage, setPreviewImage] = useState("")
+    const handleChange = useCallback((e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.readAsDataURL(file)
+        reader.addEventListener("load", () => {
+            setPreviewImage(reader.result)
+        })
+
+        
+     },[])
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>프로필 이미지 변경</DialogTitle>
+      <DialogContent>
+        <Stack direction="column" spacing={3}>
+          <Input
+            type="file"
+            inputProps={{accept: 'image/jpeg, image/jpg, image/png'}}
+            label="변결할 프로필 이미지 선택"
+            onChange={handleChange}
+          />
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            {previewImage && (
+              <AvatarEditor
+                image={previewImage}
+                width={120}
+                height={120}
+                border={50}
+                scale={2}
+                style={{display: 'inline'}}
+              />
+            )}
+          </div>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>취소</Button>
+        <Button>확인</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default ProfileModal

--- a/src/components/Modal/ProfileModal.jsx
+++ b/src/components/Modal/ProfileModal.jsx
@@ -1,21 +1,69 @@
-import React, { useState } from 'react'
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Input, Stack } from '@mui/material';
-import { useCallback } from 'react';
+import React, {useEffect, useRef, useState} from 'react';
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, Input, Stack} from '@mui/material';
+import {useCallback} from 'react';
 import AvatarEditor from 'react-avatar-editor';
+import '../../firebase';
+import {useSelector} from 'react-redux';
+import {getDownloadURL, getStorage, ref as refStorage, uploadBytes} from 'firebase/storage';
+import {updateProfile} from 'firebase/auth';
+import {getDatabase, ref, update} from 'firebase/database';
 
-function ProfileModal({ open, handleClose }) {
-    const [previewImage, setPreviewImage] = useState("")
-    const handleChange = useCallback((e) => {
-        const file = e.target.files[0];
-        if (!file) return;
-        const reader = new FileReader();
-        reader.readAsDataURL(file)
-        reader.addEventListener("load", () => {
-            setPreviewImage(reader.result)
-        })
+function ProfileModal({open, handleClose}) {
+  const {user} = useSelector((state) => state);
+  const [previewImage, setPreviewImage] = useState('');
+  const [croppedImage, setCroppedImage] = useState('');
+  const [blob, setBlob] = useState('');
+  const [uploadedCroppedImage, setUploadedCroppedImage] = useState('');
+  const avatarEditorRef = useRef(null);
 
-        
-     },[])
+  const closeModal = useCallback(() => {
+    handleClose();
+    setPreviewImage('');
+    setCroppedImage('');
+    setUploadedCroppedImage('');
+  }, [handleClose]);
+
+  const handleChange = useCallback((e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.addEventListener('load', () => {
+      setPreviewImage(reader.result);
+    });
+  }, []);
+
+  const handleCropImage = useCallback(() => {
+    avatarEditorRef.current.getImageScaledToCanvas().toBlob((blob) => {
+      const imageUrl = URL.createObjectURL(blob);
+      setCroppedImage(imageUrl);
+      setBlob(blob);
+    });
+  }, []);
+
+  const uploadCroppedImage = useCallback(async () => {
+    if (!user.currentUser?.uid) return;
+    const storageRef = refStorage(getStorage(), `avatars/users/${user.currentUser.uid}`);
+    const uploadTask = await uploadBytes(storageRef, blob);
+    const downloadUrl = await getDownloadURL(uploadTask.ref);
+    setUploadedCroppedImage(downloadUrl);
+  }, [blob, user.currentUser.uid]);
+
+  useEffect(() => {
+    if (!uploadedCroppedImage || !user.currentUser) return;
+    async function changeAvatar() {
+      await updateProfile(user.currentUser, {
+        photoURL: uploadedCroppedImage,
+      });
+      const newData = {avatar: uploadedCroppedImage};
+      const updates = {};
+      updates['/users/' + user.currentUser.uid] = newData;
+      await update(ref(getDatabase()), updates);
+      closeModal();
+    }
+    changeAvatar();
+  }, [closeModal, uploadedCroppedImage, user.currentUser]);
+
   return (
     <Dialog open={open} onClose={handleClose}>
       <DialogTitle>프로필 이미지 변경</DialogTitle>
@@ -30,6 +78,7 @@ function ProfileModal({ open, handleClose }) {
           <div style={{display: 'flex', alignItems: 'center'}}>
             {previewImage && (
               <AvatarEditor
+                ref={avatarEditorRef}
                 image={previewImage}
                 width={120}
                 height={120}
@@ -38,15 +87,19 @@ function ProfileModal({ open, handleClose }) {
                 style={{display: 'inline'}}
               />
             )}
+            {croppedImage && (
+              <img alt="cropped" style={{marginLeft: '50px'}} width={100} height={100} src={croppedImage} />
+            )}
           </div>
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>취소</Button>
-        <Button>확인</Button>
+        <Button onClick={closeModal}>취소</Button>
+        {previewImage && <Button onClick={handleCropImage}>이미지 변경</Button>}
+        {croppedImage && <Button onClick={uploadCroppedImage}>이미지 적용</Button>}
       </DialogActions>
     </Dialog>
   );
 }
 
-export default ProfileModal
+export default ProfileModal;


### PR DESCRIPTION
# 프로필 이미지 변경 모달 구현 

* 상단의 프로필 이미지를 클릭하고 `프로필 이미지` 항목을 클릭하면 이미지 파일을 선택하는 `Dialog`가 나타나며 이미지를 선택하는 순간 `AvatarEditor`가 표시되게 설정함


# 프로필 이미지 변경 기능 구현

* 사용자가 `프로필 이미지`항목을 클릭하면 나타나는 modal 창에서 이미지를 선택하고 편집한 다음 적용을 하면 프로필 이미지가 적용되는 기능을 구현함

* `Dialog` input 을 file로 해서 파일을 선택할수 있게 하고, 선택하는 순간 `AvatarEditor`가 렌더링되어 이미지를 원하는 영역을 선택하여 편집할수 있게 한 다음 `이미지 변경` 버튼을 누르면 `handleCropImage`가 호출됨

*  `AvatarEditor`컴포넌트를 통해 편집된 이미지를 url로 변경하여  usestate중 하나인 scroppedImage와 blob에 값을 업데이트함

* 그렇게해서 편집된 이미지를 렌더링 해서 미리 보여주고 `이미지 적용`버튼을 클릭하면 `uploadCroppedImage`를 호출함
firebase에서 storage를 불러오고 `uploadBytes`와 `getDounloadURL`메소드를 호출하고 `uploadedCroppedImage`의 값을 변경함

firebase 업로드 관련 메소드 자료: https://firebase.google.com/docs/storage/web/upload-files?hl=ko

* uploadedCroppedImage가 변경될 때마다 firebase 데이터베이스에 있는 사용자의 데이터 중에서 photoURL의 데이터가 변경되게 설정함


