### PR TITLE
테마 기능 구현 

### DIFF
--- a/src/Pages/Main.jsx
+++ b/src/Pages/Main.jsx
@@ -6,11 +6,13 @@ import { Drawer, Toolbar } from '@mui/material';
 import Chat from '../components/Chat/Chat';
 import ThemeMenu from './../components/Menu/ThemeMenu';
 import ChannelMenu from './../components/Menu/ChannelMenu';
+import { useSelector } from 'react-redux';
 
 function Main() {
+  const { theme } = useSelector(state=>state)
     return (
-      //TODO backgroundColor 테마 적용
-      <Box sx={{display: 'flex', backgroundColor: 'white'}}>
+      
+      <Box sx={{display: 'flex', backgroundColor: theme.subTheme}}>
         <Header></Header>
         <Drawer variant="permanent" sx={{width: 300}} className="no-scroll">
           <Toolbar />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,7 +10,7 @@ import { getAuth } from 'firebase/auth';
 import ProfileModal from './Modal/ProfileModal';
 function Header() {
   const [showProfileModal, setShowProfileModal] = useState(false);
-    const { user } = useSelector(state => state)
+    const { user, theme } = useSelector(state => state)
   const [anchorEl, setAnchorEl] = useState(null);
  
   const handleCloseMenu = () => setAnchorEl(null);
@@ -33,10 +33,9 @@ function Header() {
 
   return (
     <>
-      {/* TODO backgroundColor 테마 적용 */}
       <AppBar
         position="fixed"
-        sx={{zIndex: (theme) => theme.zIndex.drawer + 1, color: '#9A9398', backgroundColor: '#d8bbdf'}}
+        sx={{zIndex: (theme) => theme.zIndex.drawer + 1, color: '#9A9398', backgroundColor: theme.mainTheme}}
       >
         <Toolbar sx={{display: 'flex', justifyContent: 'space-between', height: '50px'}}>
           <Box sx={{display: 'flex'}}>

--- a/src/components/Menu/ChannelMenu.jsx
+++ b/src/components/Menu/ChannelMenu.jsx
@@ -18,10 +18,11 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import "../../firebase"
 import { child, getDatabase, onChildAdded, push, ref, update } from 'firebase/database';
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { setCurrentChannel } from '../../store/channelReducer';
 
 function ChannelMenu() {
+  const {theme} = useSelector((state)=>state)
   const [open, setOpen] = useState(false);
   const [channelName, setChannelName] = useState('');
   const [channelDetail, setChannelDetail] = useState('');
@@ -83,8 +84,8 @@ function ChannelMenu() {
 
   return (
     <>
-      {/* TODO 테마 반영을 할 예정이므로 추후 수정 */}
-      <List sx={{overflow: 'auto', width: 240, backgroundColor: '#123123'}}>
+      
+      <List sx={{overflow: 'auto', width: 240, backgroundColor: theme.mainTheme}}>
         <ListItem
           secondaryAction={
             <IconButton sx={{color: '#aebbb5'}} onClick={handleClickOpen}>

--- a/src/components/Menu/ThemeMenu.jsx
+++ b/src/components/Menu/ThemeMenu.jsx
@@ -14,7 +14,8 @@ import PaletteIcon from '@mui/icons-material/Palette';
 import {HexColorPicker} from 'react-colorful';
 import '../../firebase';
 import {child, getDatabase, onChildAdded, push, ref, update} from 'firebase/database';
-import {useSelector} from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { setTheme } from '../../store/themeReducer';
 
 function ThemeMenu() {
   const {user} = useSelector((state) => state);
@@ -26,7 +27,7 @@ function ThemeMenu() {
   const handleClose = useCallback(() => setShowThemeModal(false), []);
   const handleChangeMain = useCallback((color) => setMainTheme(color), []);
   const handleChangeSub = useCallback((color) => setSubTheme(color), []);
-
+    const dispatch = useDispatch();
     const handleSaveTheme = useCallback(async () => {
         if (!user.currentUser?.uid) return;
     try {
@@ -54,7 +55,9 @@ function ThemeMenu() {
             setUserTheme([])
             unsubscribe?.();
         }
-    },[user.currentUser.uid])
+    }, [user.currentUser.uid])
+    
+
   return (
     <>
       <List sx={{overflow: 'auto', width: 60, backgroundColor: '#150c16'}}>
@@ -65,7 +68,7 @@ function ThemeMenu() {
         </ListItem>
         {userTheme.map((theme,i) => (
             <ListItem key={i}>
-            <div className="theme-box">
+            <div className="theme-box" onClick={() => {dispatch(setTheme(theme.mainTheme,theme.subTheme))}}>
               <div className="theme-main" style={{backgroundColor: theme.mainTheme}}></div>
 
               <div className="theme-sub" style={{backgroundColor: theme.subTheme}}></div>

--- a/src/components/Menu/ThemeMenu.jsx
+++ b/src/components/Menu/ThemeMenu.jsx
@@ -1,14 +1,60 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, List, ListItem, ListItemIcon, Stack } from '@mui/material'
-import React, { useCallback, useState } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemIcon,
+  Stack,
+} from '@mui/material';
+import React, {useCallback, useEffect, useState} from 'react';
 import PaletteIcon from '@mui/icons-material/Palette';
-import { HexColorPicker } from 'react-colorful';
-
+import {HexColorPicker} from 'react-colorful';
+import '../../firebase';
+import {child, getDatabase, onChildAdded, push, ref, update} from 'firebase/database';
+import {useSelector} from 'react-redux';
 
 function ThemeMenu() {
-    const [showThemeModal, setShowThemeModal] = useState(false)
+  const {user} = useSelector((state) => state);
+  const [showThemeModal, setShowThemeModal] = useState(false);
+  const [mainTheme, setMainTheme] = useState('#ffffff');
+    const [subTheme, setSubTheme] = useState('#ffffff');
+    const [userTheme, setUserTheme] = useState([]);
+  const handleClickOpen = useCallback(() => setShowThemeModal(true), []);
+  const handleClose = useCallback(() => setShowThemeModal(false), []);
+  const handleChangeMain = useCallback((color) => setMainTheme(color), []);
+  const handleChangeSub = useCallback((color) => setSubTheme(color), []);
 
-    const handleClickOpen = useCallback(() => setShowThemeModal(true),[]);
-    const handleClose = useCallback(() => setShowThemeModal(false),[]);
+    const handleSaveTheme = useCallback(async () => {
+        if (!user.currentUser?.uid) return;
+    try {
+      const db = getDatabase();
+      const key = push(child(ref(db), '/users/' + user.currentUser.uid + '/theme')).key;
+      const newTheme = {mainTheme, subTheme};
+      const updates = {};
+      updates['/users/' + user.currentUser.uid + '/theme/' + key] = newTheme;
+      await update(ref(db), updates);
+      handleClose();
+    } catch (error) {
+      console.error(error);
+      handleClose();
+    }
+    }, [handleClose, mainTheme, subTheme, user.currentUser.uid]);
+    
+    useEffect(() => {
+        if (!user.currentUser?.uid) return;
+        const db = getDatabase();
+        const themeRef = ref(db, 'users/' + user.currentUser.uid + '/theme');
+        const unsubscribe = onChildAdded(themeRef, (snap) => {
+            setUserTheme((themeArr) => [snap.val(), ...themeArr])
+        }) 
+        return () => {
+            setUserTheme([])
+            unsubscribe?.();
+        }
+    },[user.currentUser.uid])
   return (
     <>
       <List sx={{overflow: 'auto', width: 60, backgroundColor: '#150c16'}}>
@@ -17,13 +63,15 @@ function ThemeMenu() {
             <PaletteIcon />
           </ListItemIcon>
         </ListItem>
-        <ListItem>
-          <div className="theme-box">
-            <div className="theme-main" style={{backgroundColor: 'red'}}></div>
+        {userTheme.map((theme,i) => (
+            <ListItem key={i}>
+            <div className="theme-box">
+              <div className="theme-main" style={{backgroundColor: theme.mainTheme}}></div>
 
-            <div className="theme-sub" style={{backgroundColor: 'white'}}></div>
-          </div>
-        </ListItem>
+              <div className="theme-sub" style={{backgroundColor: theme.subTheme}}></div>
+            </div>
+          </ListItem>
+        ))}
       </List>
       <Dialog open={showThemeModal} onClose={handleClose}>
         <DialogTitle>테마 색상 선택</DialogTitle>
@@ -31,21 +79,21 @@ function ThemeMenu() {
           <Stack direction="row" spacing={2}>
             <div>
               Main
-              <HexColorPicker />
+              <HexColorPicker color={mainTheme} onChange={handleChangeMain} />
             </div>
             <div>
               sub
-              <HexColorPicker />
+              <HexColorPicker color={subTheme} onChange={handleChangeSub} />
             </div>
           </Stack>
         </DialogContent>
         <DialogActions>
-                  <Button onClick={handleClose}>취소</Button>
-          <Button>테마 저장</Button>
+          <Button onClick={handleClose}>취소</Button>
+          <Button onClick={handleSaveTheme}>테마 저장</Button>
         </DialogActions>
       </Dialog>
     </>
   );
 }
 
-export default ThemeMenu
+export default ThemeMenu;

--- a/src/components/Modal/ProfileModal.jsx
+++ b/src/components/Modal/ProfileModal.jsx
@@ -55,9 +55,8 @@ function ProfileModal({open, handleClose}) {
       await updateProfile(user.currentUser, {
         photoURL: uploadedCroppedImage,
       });
-      const newData = {avatar: uploadedCroppedImage};
       const updates = {};
-      updates['/users/' + user.currentUser.uid] = newData;
+      updates['/users/' + user.currentUser.uid + '/avatar'] = uploadedCroppedImage;
       await update(ref(getDatabase()), updates);
       closeModal();
     }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,11 +1,13 @@
 
 import { combineReducers } from "redux";
 import channelReducer from "./channelReducer";
+import themeReducer from "./themeReducer";
 import userReducer from './userReducer';
 
 const rootReducer = combineReducers({
     user: userReducer,
-    channel: channelReducer
+    channel: channelReducer,
+    theme: themeReducer
 })
 
 

--- a/src/store/themeReducer.js
+++ b/src/store/themeReducer.js
@@ -1,0 +1,21 @@
+const SET_THEME = "SET_THEME";
+
+export const setTheme = (mainTheme, subTheme) => ({ type: SET_THEME, mainTheme, subTheme })
+
+const initialState = { mainTheme: "#4c3c4c", subTheme: "#eee" }
+
+
+const themeReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case SET_THEME:
+            return {
+                mainTheme: action.mainTheme,
+                subTheme: action.subTheme
+            };
+        default:
+            return state;
+    }
+}
+
+
+export default themeReducer;


### PR DESCRIPTION
# 코드 수정

이전에 구현한 프로필 이미지 변경 기능에서 firebase의 데이터 유형중 `name`이 사라지게 되어서 코드를 수정함
 `newData`를 제거하고 firebase 데이터베이스 경로에 직접적으로 update를 해서 기존에 있는 유저 정보(name)를 건드리지 않게 수정함

# 테마 색상 firebase 연동

 사용자가 색상을 선택하고 `테마 저장`을 클릭하면 `mainTheme`과 `녀ㅠ쏘듣`의 색상 정보를 firebase 데이터베이스에 저장하고 해당 데이터를 불러와서 테마 리스트를 렌더링함

# 테마 store 구현 및 테마 색상 적용
테마 색상 데이터 상태를 관리하는 `themeReducer`를 구현함  테마를 클릭하면 `setTheme`이 dispatch 되어서 mainTheme 과 subTheme 의 값이 변경되고, 각각의 컴포넌트의 색상 값으로 대체해줌

mainTheme  :  Header , ChannelMenu
subTheme : Main